### PR TITLE
Integrate frontend flows with local API

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -1,45 +1,44 @@
 const express = require('express')
 const cors = require('cors')
-const listings = require('./listingsData')
-const tenants = require('./tenantsData')
+const seedListings = require('./listingsData')
+const seedTenants = require('./tenantsData')
 
 const app = express()
 
 app.use(cors())
 app.use(express.json())
 
-let listings = [
+let listings = seedListings.map((listing) => ({ ...listing }))
+let tenants = seedTenants.map((tenant) => ({ ...tenant }))
+let users = [
   {
-    id: 1,
-    name: 'NYC Apartment',
-    location: 'Manhattan',
-    price: '$1200/month',
-    rating: 4.7,
-    details: 'Details',
-    description: 'Spacious Manhattan apartment close to campus and transit.',
-    owner: 'Kaiyuan Wu',
-  },
-  {
-    id: 2,
-    name: 'Brooklyn Room',
-    location: 'Brooklyn',
-    price: '$900/month',
-    rating: 4.5,
-    details: 'Details',
-    description: 'Cozy Brooklyn room in a quiet neighborhood.',
-    owner: 'Kaiyuan Wu',
-  },
-  {
-    id: 3,
-    name: 'Queens Studio',
-    location: 'Queens',
-    price: '$1100/month',
-    rating: 4.6,
-    details: 'Details',
-    description: 'Private studio with easy subway access.',
-    owner: 'Other User',
+    id: 'demo',
+    name: 'Kaiyuan Wu',
+    email: 'demo@subvet.app',
+    password: 'password123',
   },
 ]
+let applications = []
+let contactRequests = []
+
+function badRequest(res, message) {
+  return res.status(400).json({ error: message })
+}
+
+function normalizeEmail(email) {
+  return String(email ?? '')
+    .trim()
+    .toLowerCase()
+}
+
+function findUserById(userId) {
+  return users.find((user) => user.id === String(userId))
+}
+
+function nextNumericId(items) {
+  return items.length > 0 ? Math.max(...items.map((item) => Number(item.id) || 0)) + 1 : 1
+}
+
 app.get('/health', (req, res) => res.json({ ok: true }))
 app.get('/api/health', (req, res) => res.json({ ok: true }))
 
@@ -47,55 +46,231 @@ app.get('/api/listings', (req, res) => {
   res.json(listings)
 })
 
-app.post('/api/listings', (req, res) => {
-  const { name, location, price, rating, details, description, owner } = req.body
 app.get('/api/listings/:id', (req, res) => {
   const id = Number(req.params.id)
-  const listing = listings.find((l) => l.id === id)
-
-  if (!name || !location || !price) {
-    return res.status(400).json({ error: 'name, location, and price are required' })
+  const listing = listings.find((item) => item.id === id)
+  if (!listing) {
+    return res.status(404).json({ error: 'Listing not found' })
   }
+  return res.json(listing)
+})
 
-  const nextId =
-    listings.length > 0 ? Math.max(...listings.map((l) => l.id)) + 1 : 1
-
-  const newListing = {
-    id: nextId,
+app.post('/api/listings', (req, res) => {
+  const {
     name,
     location,
     price,
-    rating: typeof rating === 'number' ? rating : 4.0,
-    details: details || 'Details',
-    description: description || 'No description provided yet.',
-    owner: owner || 'Kaiyuan Wu',
+    rating,
+    details,
+    description,
+    owner,
+    bhk,
+    area,
+    rentUsd,
+    mapQuery,
+  } = req.body ?? {}
+
+  if (!name || !location || !price) {
+    return badRequest(res, 'name, location, and price are required')
   }
 
-  listings.push(newListing)
-  res.status(201).json(newListing)
+  const nextId = nextNumericId(listings)
+  const normalizedRent = Number(rentUsd)
+  const listing = {
+    id: nextId,
+    name: String(name).trim(),
+    location: String(location).trim(),
+    price: String(price).trim(),
+    rating:
+      typeof rating === 'number' || typeof rating === 'string'
+        ? String(rating)
+        : '4.5',
+    details: details ? String(details).trim() : 'Private room · shared unit',
+    description: description ? String(description).trim() : 'No description provided yet.',
+    owner: owner ? String(owner).trim() : 'Kaiyuan Wu',
+    bhk: bhk ? String(bhk) : 'room',
+    area: area ? String(area).trim() : String(location).trim(),
+    rentUsd: Number.isFinite(normalizedRent) ? normalizedRent : null,
+    mapQuery: mapQuery ? String(mapQuery).trim() : `${String(location).trim()}, New York, NY`,
+  }
+
+  listings.push(listing)
+  return res.status(201).json(listing)
 })
 
-module.exports = app
 app.get('/api/tenants', (req, res) => {
   res.json(tenants)
 })
 
 app.get('/api/tenants/:id', (req, res) => {
-  const tenant = tenants.find((t) => t.id === String(req.params.id))
-  if (!tenant) return res.status(404).json({ error: 'Tenant not found' })
-  res.json(tenant)
+  const tenant = tenants.find((item) => item.id === String(req.params.id))
+  if (!tenant) {
+    return res.status(404).json({ error: 'Tenant not found' })
+  }
+  return res.json(tenant)
+})
+
+app.post('/api/tenants', (req, res) => {
+  const {
+    displayName,
+    age,
+    neighborhoods,
+    subleaseWindow,
+    budget,
+    intro,
+    ideal,
+    questions,
+    company,
+  } = req.body ?? {}
+
+  if (!displayName || !age || !neighborhoods || !subleaseWindow) {
+    return badRequest(res, 'displayName, age, neighborhoods, and subleaseWindow are required')
+  }
+
+  const nextId = String(nextNumericId(tenants))
+  const tenant = {
+    id: nextId,
+    displayName: String(displayName).trim(),
+    age: Number(age),
+    neighborhoods: String(neighborhoods).trim(),
+    subleaseWindow: String(subleaseWindow).trim(),
+    budget: budget ? String(budget).trim() : '$0/mo',
+    intro: intro
+      ? String(intro).trim()
+      : `${String(displayName).trim()} is looking for a summer sublease with reliable transit access.`,
+    ideal: ideal
+      ? String(ideal).trim()
+      : 'Furnished or lightly furnished, respectful roommates if shared.',
+    questions: questions ? String(questions).trim() : 'No questions yet.',
+    company: company ? String(company).trim() : 'Summer internship',
+    avatarSeed: `subvet-tenant-${nextId}`,
+  }
+
+  tenants.push(tenant)
+  return res.status(201).json(tenant)
 })
 
 app.post('/api/auth/login', (req, res) => {
-  res.json({ ok: true, user: { id: 'demo', email: req.body?.email ?? null } })
+  const email = normalizeEmail(req.body?.email)
+  const password = String(req.body?.password ?? '')
+
+  if (!email || !password) {
+    return badRequest(res, 'email and password are required')
+  }
+
+  const existing = users.find((user) => user.email === email)
+  if (existing && existing.password !== password) {
+    return res.status(401).json({ error: 'Incorrect password' })
+  }
+
+  const user =
+    existing ??
+    {
+      id: `user-${Date.now()}`,
+      name: email.split('@')[0],
+      email,
+      password,
+    }
+
+  if (!existing) {
+    users.push(user)
+  }
+
+  return res.json({
+    ok: true,
+    user: { id: user.id, name: user.name, email: user.email },
+  })
 })
 
 app.post('/api/auth/register', (req, res) => {
-  res.status(201).json({ ok: true, user: { id: 'demo', email: req.body?.email ?? null } })
+  const name = String(req.body?.name ?? '').trim()
+  const email = normalizeEmail(req.body?.email)
+  const password = String(req.body?.password ?? '')
+
+  if (!name || !email || !password) {
+    return badRequest(res, 'name, email, and password are required')
+  }
+
+  if (users.some((user) => user.email === email)) {
+    return res.status(409).json({ error: 'An account with this email already exists' })
+  }
+
+  const user = {
+    id: `user-${Date.now()}`,
+    name,
+    email,
+    password,
+  }
+
+  users.push(user)
+  return res.status(201).json({
+    ok: true,
+    user: { id: user.id, name: user.name, email: user.email },
+  })
 })
 
 app.post('/api/applications', (req, res) => {
-  res.status(201).json({ ok: true })
+  const listingId = Number(req.body?.listingId)
+  const userId = String(req.body?.userId ?? '')
+  const listing = listings.find((item) => item.id === listingId)
+  const user = findUserById(userId)
+
+  if (!Number.isFinite(listingId) || !userId) {
+    return badRequest(res, 'listingId and userId are required')
+  }
+
+  if (!listing) {
+    return res.status(404).json({ error: 'Listing not found' })
+  }
+
+  if (!user) {
+    return res.status(404).json({ error: 'User not found' })
+  }
+
+  const application = {
+    id: `app-${Date.now()}`,
+    listingId,
+    userId,
+    createdAt: new Date().toISOString(),
+  }
+
+  applications.push(application)
+  return res.status(201).json({ ok: true, application })
+})
+
+app.post('/api/contact-requests', (req, res) => {
+  const targetType = String(req.body?.targetType ?? '')
+  const targetId = String(req.body?.targetId ?? '')
+  const userId = String(req.body?.userId ?? '')
+
+  if (!targetType || !targetId || !userId) {
+    return badRequest(res, 'targetType, targetId, and userId are required')
+  }
+
+  if (!findUserById(userId)) {
+    return res.status(404).json({ error: 'User not found' })
+  }
+
+  if (targetType === 'listing') {
+    const listing = listings.find((item) => item.id === Number(targetId))
+    if (!listing) return res.status(404).json({ error: 'Listing not found' })
+  } else if (targetType === 'tenant') {
+    const tenant = tenants.find((item) => item.id === targetId)
+    if (!tenant) return res.status(404).json({ error: 'Tenant not found' })
+  } else {
+    return badRequest(res, 'targetType must be "listing" or "tenant"')
+  }
+
+  const contactRequest = {
+    id: `contact-${Date.now()}`,
+    targetType,
+    targetId,
+    userId,
+    createdAt: new Date().toISOString(),
+  }
+
+  contactRequests.push(contactRequest)
+  return res.status(201).json({ ok: true, contactRequest })
 })
 
 app.use((req, res) => {
@@ -107,6 +282,4 @@ app.use((err, req, res, next) => {
   res.status(500).json({ error: 'Internal Server Error' })
 })
 
-
 module.exports = app
-

--- a/back-end/server.js
+++ b/back-end/server.js
@@ -1,6 +1,6 @@
 const app = require('./app')
 
-const PORT = 3000
+const PORT = Number(process.env.PORT) || 3000
 
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`)

--- a/front-end/src/AddListingPage.jsx
+++ b/front-end/src/AddListingPage.jsx
@@ -1,5 +1,8 @@
 import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+import { useAuth } from './hooks/useAuth'
+import { useListings } from './hooks/useListings'
+import { useTenants } from './hooks/useTenants'
 import MainNav from './MainNav'
 import './AddListingPage.css'
 
@@ -10,18 +13,36 @@ const initialForm = {
   sublessorAddress: '',
   sublessorFrom: '',
   sublessorTo: '',
+  sublessorPrice: '',
   sublessorDetails: '',
   tenantNeighborhoods: '',
   tenantFrom: '',
   tenantTo: '',
+  tenantBudget: '',
   tenantIdeal: '',
   tenantComments: '',
 }
 
+function formatWindow(start, end) {
+  if (!start || !end) return 'Flexible summer dates'
+
+  const formatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+  return `${formatter.format(new Date(start))} - ${formatter.format(new Date(end))}`
+}
+
+function formatMonthlyPrice(amount) {
+  const value = Number(amount)
+  if (!Number.isFinite(value) || value <= 0) return null
+  return `$${value.toLocaleString('en-US')}/mo`
+}
+
 function AddListingPage() {
   const navigate = useNavigate()
+  const { user } = useAuth()
+  const { createListing } = useListings()
+  const { createTenant } = useTenants()
   const [form, setForm] = useState(initialForm)
-  const [submitted, setSubmitted] = useState(false)
+  const [submitted, setSubmitted] = useState(null)
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState('')
 
@@ -35,44 +56,52 @@ function AddListingPage() {
     setSubmitError('')
 
     const isSublessor = form.role === 'sublessor'
-
-    const payload = isSublessor
-      ? {
-          name: form.name || 'New Listing',
-          location: form.sublessorAddress || 'New York',
-          price: '$1000/month',
-          rating: 4.5,
-          details: 'Details',
-          description: form.sublessorDetails || 'New sublease listing',
-          owner: 'Kaiyuan Wu',
-        }
-      : {
-          name: `${form.name || 'Tenant'} Application`,
-          location: form.tenantNeighborhoods || 'New York',
-          price: '$0/month',
-          rating: 4.0,
-          details: 'Details',
-          description: form.tenantIdeal || form.tenantComments || 'Tenant application',
-          owner: 'Kaiyuan Wu',
-        }
+    const actorName = user?.name || 'Kaiyuan Wu'
 
     try {
-      const res = await fetch('http://localhost:3000/api/listings', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(payload),
-      })
+      if (isSublessor) {
+        const monthlyPrice = formatMonthlyPrice(form.sublessorPrice)
+        if (!monthlyPrice) {
+          throw new Error('Enter a valid monthly rent.')
+        }
 
-      if (!res.ok) {
-        throw new Error('Failed to submit listing')
+        const createdListing = await createListing({
+          name: form.name || 'New Listing',
+          location: form.sublessorAddress || 'New York',
+          price: monthlyPrice,
+          rating: 4.5,
+          details: formatWindow(form.sublessorFrom, form.sublessorTo),
+          description: form.sublessorDetails || 'New sublease listing',
+          owner: actorName,
+          bhk: 'room',
+          area: form.sublessorAddress || 'New York',
+          rentUsd: Number(form.sublessorPrice),
+          mapQuery: form.sublessorAddress || 'New York, NY',
+        })
+
+        setSubmitted({ role: 'sublessor', targetId: createdListing.id })
+      } else {
+        const budget = formatMonthlyPrice(form.tenantBudget)
+        if (!budget) {
+          throw new Error('Enter a valid monthly budget.')
+        }
+
+        const createdTenant = await createTenant({
+          displayName: form.name || actorName,
+          age: Number(form.age),
+          neighborhoods: form.tenantNeighborhoods,
+          subleaseWindow: formatWindow(form.tenantFrom, form.tenantTo),
+          budget,
+          intro: `${form.name || actorName} is looking for a summer sublease in ${form.tenantNeighborhoods}.`,
+          ideal: form.tenantIdeal || 'Flexible on layout, but looking for a clean and safe place.',
+          questions: form.tenantComments || 'No questions yet.',
+          company: user?.name || 'Summer internship',
+        })
+
+        setSubmitted({ role: 'tenant', targetId: createdTenant.id })
       }
-
-      await res.json()
-      setSubmitted(true)
     } catch (err) {
-      setSubmitError('Could not submit listing right now.')
+      setSubmitError(err.message || 'Could not submit listing right now.')
     } finally {
       setSubmitting(false)
     }
@@ -80,17 +109,23 @@ function AddListingPage() {
 
   function handleReset() {
     setForm(initialForm)
-    setSubmitted(false)
+    setSubmitted(null)
     setSubmitError('')
   }
 
   if (submitted) {
+    const isSublessor = submitted.role === 'sublessor'
+
     return (
       <div className="add-listing-page">
         <div className="add-listing-shell add-listing-shell--done">
           <div className="add-listing-success">
             <h1 className="add-listing-title add-listing-title--plain">Thanks</h1>
-            <p className="add-listing-success-text">Your application was received.</p>
+            <p className="add-listing-success-text">
+              {isSublessor
+                ? 'Your sublease listing is live.'
+                : 'Your tenant profile has been added to the tenant directory.'}
+            </p>
             <div className="add-listing-success-actions">
               <button type="button" className="add-listing-btn add-listing-btn--secondary" onClick={handleReset}>
                 Submit another
@@ -98,9 +133,11 @@ function AddListingPage() {
               <button
                 type="button"
                 className="add-listing-btn add-listing-btn--primary"
-                onClick={() => navigate('/profile')}
+                onClick={() =>
+                  navigate(isSublessor ? '/profile' : `/tenant/${submitted.targetId}`)
+                }
               >
-                Go to profile
+                {isSublessor ? 'Go to profile' : 'View tenant profile'}
               </button>
             </div>
           </div>
@@ -221,6 +258,19 @@ function AddListingPage() {
                 </label>
               </div>
               <label className="add-listing-field">
+                <span className="add-listing-label">Monthly rent</span>
+                <input
+                  className="add-listing-input"
+                  type="number"
+                  min={1}
+                  inputMode="numeric"
+                  placeholder="1200"
+                  value={form.sublessorPrice}
+                  onChange={(e) => update('sublessorPrice', e.target.value)}
+                  required
+                />
+              </label>
+              <label className="add-listing-field">
                 <span className="add-listing-label">Sublet details</span>
                 <textarea
                   className="add-listing-textarea"
@@ -276,6 +326,19 @@ function AddListingPage() {
                 </label>
               </div>
               <label className="add-listing-field">
+                <span className="add-listing-label">Monthly budget</span>
+                <input
+                  className="add-listing-input"
+                  type="number"
+                  min={1}
+                  inputMode="numeric"
+                  placeholder="1100"
+                  value={form.tenantBudget}
+                  onChange={(e) => update('tenantBudget', e.target.value)}
+                  required
+                />
+              </label>
+              <label className="add-listing-field">
                 <span className="add-listing-label">Ideal apartment</span>
                 <textarea
                   className="add-listing-textarea"
@@ -308,8 +371,8 @@ function AddListingPage() {
             {submitting
               ? 'Submitting...'
               : isSublessor
-                ? 'Submit sublessor application'
-                : 'Submit rental application'}
+                ? 'Submit sublessor listing'
+                : 'Submit tenant application'}
           </button>
         </form>
 

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import './App.css'
+import { AuthProvider } from './context/AuthProvider'
 import { ListingsProvider } from './context/ListingsProvider'
 import { TenantsProvider } from './context/TenantsProvider'
 import HomePage from './HomePage'
@@ -15,25 +16,27 @@ import SavedPage from './SavedPage'
 
 function App() {
   return (
-    <ListingsProvider>
-      <TenantsProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/" element={<HomePage />} />
-            <Route path="/listings" element={<ListingsPage />} />
-            <Route path="/listing/:id" element={<ListingDetailPage />} />
-            <Route path="/listing" element={<Navigate to="/listings" replace />} />
-            <Route path="/tenants" element={<TenantsPage />} />
-            <Route path="/tenant/:tenantId" element={<TenantProfilePage />} />
-            <Route path="/profile" element={<ProfilePage />} />
-            <Route path="/add-listing" element={<AddListingPage />} />
-            <Route path="/saved" element={<SavedPage />} />
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/register" element={<RegisterPage />} />
-          </Routes>
-        </BrowserRouter>
-      </TenantsProvider>
-    </ListingsProvider>
+    <AuthProvider>
+      <ListingsProvider>
+        <TenantsProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/listings" element={<ListingsPage />} />
+              <Route path="/listing/:id" element={<ListingDetailPage />} />
+              <Route path="/listing" element={<Navigate to="/listings" replace />} />
+              <Route path="/tenants" element={<TenantsPage />} />
+              <Route path="/tenant/:tenantId" element={<TenantProfilePage />} />
+              <Route path="/profile" element={<ProfilePage />} />
+              <Route path="/add-listing" element={<AddListingPage />} />
+              <Route path="/saved" element={<SavedPage />} />
+              <Route path="/login" element={<LoginPage />} />
+              <Route path="/register" element={<RegisterPage />} />
+            </Routes>
+          </BrowserRouter>
+        </TenantsProvider>
+      </ListingsProvider>
+    </AuthProvider>
   )
 }
 

--- a/front-end/src/AuthPage.css
+++ b/front-end/src/AuthPage.css
@@ -147,10 +147,25 @@
   border-color: #222;
 }
 
+.auth-submit:disabled {
+  cursor: wait;
+  opacity: 0.72;
+}
+
 .auth-footer {
   margin-top: 0.75rem;
   font-size: 0.875rem;
   color: var(--au-muted);
+}
+
+.auth-status {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.auth-status--error {
+  color: #b42318;
 }
 
 .auth-link {
@@ -165,4 +180,3 @@
   padding-top: 0.75rem;
   border-top: 1px solid var(--au-line-soft);
 }
-

--- a/front-end/src/ListingDetailPage.css
+++ b/front-end/src/ListingDetailPage.css
@@ -248,6 +248,18 @@
   transform: scale(0.98);
 }
 
+.listing-detail-btn:disabled {
+  cursor: wait;
+  opacity: 0.72;
+}
+
+.listing-detail-inline-status {
+  margin: 0.85rem 0 0;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: #b42318;
+}
+
 .listing-detail-map-overlay {
   position: fixed;
   inset: 0;

--- a/front-end/src/ListingDetailPage.jsx
+++ b/front-end/src/ListingDetailPage.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useId, useRef, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { createContactRequest, submitApplication } from './api/actions'
 import { fetchProductById } from './api/fetchProductById'
 import MainNav from './MainNav'
+import { useAuth } from './hooks/useAuth'
 import './ListingDetailPage.css'
 
 function ListingDetailPage() {
@@ -10,12 +12,17 @@ function ListingDetailPage() {
 }
 
 function ListingDetailInner({ id }) {
+  const navigate = useNavigate()
+  const { user } = useAuth()
   const [listing, setListing] = useState(null)
   const [loadError, setLoadError] = useState(null)
   const [loading, setLoading] = useState(true)
   const [descriptionExpanded, setDescriptionExpanded] = useState(false)
   const [mapPickerOpen, setMapPickerOpen] = useState(false)
   const [actionDialog, setActionDialog] = useState(null)
+  const [actionError, setActionError] = useState('')
+  const [actionBusy, setActionBusy] = useState(false)
+  const [activeAction, setActiveAction] = useState(null)
   const mapTitleId = useId()
   const actionDialogTitleId = useId()
   const mapPrimaryActionRef = useRef(null)
@@ -25,6 +32,9 @@ function ListingDetailInner({ id }) {
 
   useEffect(() => {
     let cancelled = false
+    setLoading(true)
+    setActionError('')
+
     fetchProductById(id)
       .then((data) => {
         if (cancelled) return
@@ -79,6 +89,38 @@ function ListingDetailInner({ id }) {
     setMapPickerOpen(false)
   }
 
+  async function handleAction(kind) {
+    if (!user) {
+      navigate('/login')
+      return
+    }
+
+    setActionBusy(true)
+    setActiveAction(kind)
+    setActionError('')
+
+    try {
+      if (kind === 'apply') {
+        await submitApplication({
+          listingId: listing.id,
+          userId: user.id,
+        })
+      } else {
+        await createContactRequest({
+          targetType: 'listing',
+          targetId: String(listing.id),
+          userId: user.id,
+        })
+      }
+      setActionDialog(kind)
+    } catch (err) {
+      setActionError(err.message || 'Could not complete that action right now.')
+    } finally {
+      setActionBusy(false)
+      setActiveAction(null)
+    }
+  }
+
   if (loading) {
     return (
       <div className="listing-detail-page">
@@ -115,8 +157,6 @@ function ListingDetailInner({ id }) {
   return (
     <div className="listing-detail-page">
       <article className="listing-detail-shell">
-        <div className="listing-detail-hero">
-
         <div className="listing-detail-hero">
           <Link to="/listings" className="listing-detail-back" aria-label="Back to listings">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -160,24 +200,22 @@ function ListingDetailInner({ id }) {
           >
             ›
           </button>
-          <div className="listing-detail-dots">
-          {images.map((_, index) => (
-            <button
-              key={index}
-              type="button"
-              className={
-                index === currentImage
-                  ? 'listing-detail-dot listing-detail-dot--active'
-                  : 'listing-detail-dot'
-              }
-              onClick={() => setCurrentImage(index)}
-              aria-label={`Go to image ${index + 1}`}
-            />
-          ))}
-        </div>
-        </div>
-        
 
+          <div className="listing-detail-dots">
+            {images.map((_, index) => (
+              <button
+                key={index}
+                type="button"
+                className={
+                  index === currentImage
+                    ? 'listing-detail-dot listing-detail-dot--active'
+                    : 'listing-detail-dot'
+                }
+                onClick={() => setCurrentImage(index)}
+                aria-label={`Go to image ${index + 1}`}
+              />
+            ))}
+          </div>
         </div>
 
         <div className="listing-detail-body">
@@ -217,6 +255,8 @@ function ListingDetailInner({ id }) {
           >
             {descriptionExpanded ? 'Read less' : 'Read more'}
           </button>
+
+          {actionError ? <p className="listing-detail-inline-status">{actionError}</p> : null}
         </div>
 
         <footer className="listing-detail-footer">
@@ -228,16 +268,18 @@ function ListingDetailInner({ id }) {
             <button
               type="button"
               className="listing-detail-btn listing-detail-btn--ghost"
-              onClick={() => setActionDialog('contact')}
+              onClick={() => handleAction('contact')}
+              disabled={actionBusy}
             >
-              Contact
+              {actionBusy && activeAction === 'contact' ? 'Sending...' : 'Contact'}
             </button>
             <button
               type="button"
               className="listing-detail-btn listing-detail-btn--primary"
-              onClick={() => setActionDialog('apply')}
+              onClick={() => handleAction('apply')}
+              disabled={actionBusy}
             >
-              Apply now
+              {actionBusy && activeAction === 'apply' ? 'Submitting...' : 'Apply now'}
             </button>
           </div>
         </footer>
@@ -297,10 +339,7 @@ function ListingDetailInner({ id }) {
           role="presentation"
           onClick={() => setImageZoomOpen(false)}
         >
-          <div
-            className="listing-detail-zoom-dialog"
-            onClick={(e) => e.stopPropagation()}
-          >
+          <div className="listing-detail-zoom-dialog" onClick={(e) => e.stopPropagation()}>
             <button
               type="button"
               className="listing-detail-zoom-close"
@@ -321,11 +360,7 @@ function ListingDetailInner({ id }) {
               ‹
             </button>
 
-            <img
-              src={images[currentImage]}
-              alt=""
-              className="listing-detail-zoom-image"
-            />
+            <img src={images[currentImage]} alt="" className="listing-detail-zoom-image" />
 
             <button
               type="button"

--- a/front-end/src/LoginPage.jsx
+++ b/front-end/src/LoginPage.jsx
@@ -1,8 +1,35 @@
-import { Link } from 'react-router-dom'
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useAuth } from './hooks/useAuth'
 import MainNav from './MainNav'
 import './AuthPage.css'
 
 function LoginPage() {
+  const navigate = useNavigate()
+  const { login } = useAuth()
+  const [form, setForm] = useState({ email: '', password: '' })
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  function update(key, value) {
+    setForm((current) => ({ ...current, [key]: value }))
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setSubmitting(true)
+    setError('')
+
+    try {
+      await login(form)
+      navigate('/profile')
+    } catch (err) {
+      setError(err.message || 'Could not sign in right now.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
   return (
     <div className="auth-page">
       <div className="auth-shell">
@@ -21,12 +48,7 @@ function LoginPage() {
           <h1 className="auth-title">Sign in</h1>
         </header>
 
-        <form
-          className="auth-form"
-          onSubmit={(e) => {
-            e.preventDefault()
-          }}
-        >
+        <form className="auth-form" onSubmit={handleSubmit}>
           <label className="auth-field">
             <span className="auth-label">Email</span>
             <input
@@ -35,6 +57,9 @@ function LoginPage() {
               name="email"
               autoComplete="username"
               placeholder="you@school.edu"
+              value={form.email}
+              onChange={(e) => update('email', e.target.value)}
+              required
             />
           </label>
           <label className="auth-field">
@@ -45,10 +70,14 @@ function LoginPage() {
               name="password"
               autoComplete="current-password"
               placeholder="••••••••"
+              value={form.password}
+              onChange={(e) => update('password', e.target.value)}
+              required
             />
           </label>
-          <button type="submit" className="auth-submit">
-            Sign in
+          {error ? <p className="auth-status auth-status--error">{error}</p> : null}
+          <button type="submit" className="auth-submit" disabled={submitting}>
+            {submitting ? 'Signing in...' : 'Sign in'}
           </button>
         </form>
 
@@ -66,4 +95,3 @@ function LoginPage() {
 }
 
 export default LoginPage
-

--- a/front-end/src/ProfilePage.css
+++ b/front-end/src/ProfilePage.css
@@ -135,6 +135,24 @@
   color: var(--lp-ink);
 }
 
+.profile-email {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--lp-muted);
+}
+
+.profile-session-btn {
+  border: 1px solid var(--lp-line-soft);
+  background: #fafafa;
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--lp-ink);
+  cursor: pointer;
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+}
+
 .profile-section {
   display: flex;
   flex-direction: column;

--- a/front-end/src/ProfilePage.jsx
+++ b/front-end/src/ProfilePage.jsx
@@ -2,14 +2,18 @@ import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import ListingCard from './ListingCard'
 import MainNav from './MainNav'
+import { useAuth } from './hooks/useAuth'
 import { useListings } from './hooks/useListings'
 import './ProfilePage.css'
 
 function ProfilePage() {
+  const { user, logout } = useAuth()
   const { listings, loading } = useListings()
+  const profileName = user?.name || 'Kaiyuan Wu'
+  const profileEmail = user?.email || 'demo@subvet.app'
   const myListings = useMemo(
-    () => listings.filter((listing) => listing.owner === 'Kaiyuan Wu'),
-    [listings],
+    () => listings.filter((listing) => listing.owner === profileName),
+    [listings, profileName],
   )
   const [isEditing, setIsEditing] = useState(false)
   const [info, setInfo] = useState(
@@ -38,13 +42,19 @@ function ProfilePage() {
           <div className="profile-hero">
             <div className="profile-avatar">
               <img
-                src="https://picsum.photos/seed/subvet-profile/120/120"
+                src={`https://picsum.photos/seed/${encodeURIComponent(profileName)}/120/120`}
                 alt=""
                 width={120}
                 height={120}
               />
             </div>
-            <h2 className="profile-username">Kaiyuan Wu</h2>
+            <h2 className="profile-username">{profileName}</h2>
+            <p className="profile-email">{profileEmail}</p>
+            {user ? (
+              <button type="button" className="profile-session-btn" onClick={logout}>
+                Sign out
+              </button>
+            ) : null}
           </div>
 
           <section className="profile-section" aria-labelledby="profile-about-heading">

--- a/front-end/src/RegisterPage.jsx
+++ b/front-end/src/RegisterPage.jsx
@@ -1,8 +1,50 @@
-import { Link } from 'react-router-dom'
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useAuth } from './hooks/useAuth'
 import MainNav from './MainNav'
 import './AuthPage.css'
 
 function RegisterPage() {
+  const navigate = useNavigate()
+  const { register } = useAuth()
+  const [form, setForm] = useState({
+    name: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+  })
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  function update(key, value) {
+    setForm((current) => ({ ...current, [key]: value }))
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+
+    if (form.password !== form.confirmPassword) {
+      setError('Passwords do not match.')
+      return
+    }
+
+    setSubmitting(true)
+    setError('')
+
+    try {
+      await register({
+        name: form.name,
+        email: form.email,
+        password: form.password,
+      })
+      navigate('/profile')
+    } catch (err) {
+      setError(err.message || 'Could not create your account right now.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
   return (
     <div className="auth-page">
       <div className="auth-shell">
@@ -21,15 +63,18 @@ function RegisterPage() {
           <h1 className="auth-title">Create account</h1>
         </header>
 
-        <form
-          className="auth-form"
-          onSubmit={(e) => {
-            e.preventDefault()
-          }}
-        >
+        <form className="auth-form" onSubmit={handleSubmit}>
           <label className="auth-field">
             <span className="auth-label">Display name</span>
-            <input className="auth-input" type="text" name="name" placeholder="Your name" />
+            <input
+              className="auth-input"
+              type="text"
+              name="name"
+              placeholder="Your name"
+              value={form.name}
+              onChange={(e) => update('name', e.target.value)}
+              required
+            />
           </label>
           <label className="auth-field">
             <span className="auth-label">Email</span>
@@ -39,6 +84,9 @@ function RegisterPage() {
               name="email"
               autoComplete="email"
               placeholder="you@school.edu"
+              value={form.email}
+              onChange={(e) => update('email', e.target.value)}
+              required
             />
           </label>
           <label className="auth-field">
@@ -49,6 +97,9 @@ function RegisterPage() {
               name="password"
               autoComplete="new-password"
               placeholder="At least 8 characters"
+              value={form.password}
+              onChange={(e) => update('password', e.target.value)}
+              required
             />
           </label>
           <label className="auth-field">
@@ -59,10 +110,14 @@ function RegisterPage() {
               name="confirmPassword"
               autoComplete="new-password"
               placeholder="Re-enter password"
+              value={form.confirmPassword}
+              onChange={(e) => update('confirmPassword', e.target.value)}
+              required
             />
           </label>
-          <button type="submit" className="auth-submit">
-            Create account
+          {error ? <p className="auth-status auth-status--error">{error}</p> : null}
+          <button type="submit" className="auth-submit" disabled={submitting}>
+            {submitting ? 'Creating account...' : 'Create account'}
           </button>
         </form>
 
@@ -80,4 +135,3 @@ function RegisterPage() {
 }
 
 export default RegisterPage
-

--- a/front-end/src/TenantProfilePage.css
+++ b/front-end/src/TenantProfilePage.css
@@ -188,6 +188,13 @@
   color: var(--vp-ink);
 }
 
+.tenant-profile-status {
+  margin: 0.4rem 0 0;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  color: var(--vp-muted);
+}
+
 .tenant-profile-contact {
   flex-shrink: 0;
   padding: 0.65rem 1.25rem;
@@ -205,6 +212,11 @@
 .tenant-profile-contact:hover {
   background: #222;
   border-color: #222;
+}
+
+.tenant-profile-contact:disabled {
+  cursor: wait;
+  opacity: 0.72;
 }
 
 .tenant-profile-page .bottom-nav {

--- a/front-end/src/TenantProfilePage.jsx
+++ b/front-end/src/TenantProfilePage.jsx
@@ -1,11 +1,41 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { createContactRequest } from './api/actions'
+import { getTenantById } from './api/tenants'
 import MainNav from './MainNav'
+import { useAuth } from './hooks/useAuth'
 import { useTenants } from './hooks/useTenants'
-import { normalizeDummyUser } from './tenants/normalizeDummyUser'
 import './TenantProfilePage.css'
 
 function TenantProfileDetail({ tenant }) {
+  const navigate = useNavigate()
+  const { user } = useAuth()
+  const [submitting, setSubmitting] = useState(false)
+  const [status, setStatus] = useState('')
+
+  async function handleContact() {
+    if (!user) {
+      navigate('/login')
+      return
+    }
+
+    setSubmitting(true)
+    setStatus('')
+
+    try {
+      await createContactRequest({
+        targetType: 'tenant',
+        targetId: tenant.id,
+        userId: user.id,
+      })
+      setStatus('Contact request sent.')
+    } catch (err) {
+      setStatus(err.message || 'Could not send your contact request.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
   return (
     <div className="tenant-profile-page">
       <article className="tenant-profile-shell">
@@ -74,9 +104,10 @@ function TenantProfileDetail({ tenant }) {
           <div>
             <p className="tenant-profile-price-label">Budget</p>
             <p className="tenant-profile-price">{tenant.budget}</p>
+            {status ? <p className="tenant-profile-status">{status}</p> : null}
           </div>
-          <button type="button" className="tenant-profile-contact">
-            Contact
+          <button type="button" className="tenant-profile-contact" onClick={handleContact} disabled={submitting}>
+            {submitting ? 'Sending...' : 'Contact'}
           </button>
         </footer>
         <MainNav active="tenants" />
@@ -90,18 +121,19 @@ function TenantProfileFetchById({ id }) {
 
   useEffect(() => {
     let cancelled = false
-    fetch(
-      `https://dummyjson.com/users/${id}?select=id,firstName,lastName,age,company,address,university`,
-    )
-      .then((r) => (r.ok ? r.json() : null))
-      .then((u) => {
-        if (cancelled) return
-        const t = u ? normalizeDummyUser(u) : null
-        setState({ status: t ? 'ok' : 'missing', tenant: t })
+
+    getTenantById(id)
+      .then((tenant) => {
+        if (!cancelled) {
+          setState({ status: 'ok', tenant })
+        }
       })
       .catch(() => {
-        if (!cancelled) setState({ status: 'missing', tenant: null })
+        if (!cancelled) {
+          setState({ status: 'missing', tenant: null })
+        }
       })
+
     return () => {
       cancelled = true
     }
@@ -140,7 +172,7 @@ function TenantProfilePage() {
   const { tenants, loading, error } = useTenants()
 
   const fromList = useMemo(
-    () => (tenantId ? tenants.find((t) => t.id === tenantId) : undefined),
+    () => (tenantId ? tenants.find((tenant) => tenant.id === tenantId) : undefined),
     [tenants, tenantId],
   )
 
@@ -173,7 +205,7 @@ function TenantProfilePage() {
     return <TenantProfileDetail tenant={fromList} />
   }
 
-  if (tenantId && /^\d+$/.test(tenantId)) {
+  if (tenantId) {
     return <TenantProfileFetchById key={tenantId} id={tenantId} />
   }
 

--- a/front-end/src/api/actions.js
+++ b/front-end/src/api/actions.js
@@ -1,0 +1,16 @@
+import { apiRequest } from './client'
+
+export function submitApplication(payload) {
+  return apiRequest('/applications', {
+    method: 'POST',
+    body: payload,
+  })
+}
+
+export function createContactRequest(payload) {
+  return apiRequest('/contact-requests', {
+    method: 'POST',
+    body: payload,
+  })
+}
+

--- a/front-end/src/api/auth.js
+++ b/front-end/src/api/auth.js
@@ -1,0 +1,16 @@
+import { apiRequest } from './client'
+
+export function loginUser(payload) {
+  return apiRequest('/auth/login', {
+    method: 'POST',
+    body: payload,
+  })
+}
+
+export function registerUser(payload) {
+  return apiRequest('/auth/register', {
+    method: 'POST',
+    body: payload,
+  })
+}
+

--- a/front-end/src/api/client.js
+++ b/front-end/src/api/client.js
@@ -1,0 +1,44 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000/api'
+
+export class ApiError extends Error {
+  constructor(message, status) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+  }
+}
+
+async function parseResponse(res) {
+  const text = await res.text()
+  if (!text) return null
+
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+export async function apiRequest(path, options = {}) {
+  const hasBody = options.body !== undefined
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    ...options,
+    headers: {
+      ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
+      ...(options.headers ?? {}),
+    },
+    body: hasBody ? JSON.stringify(options.body) : undefined,
+  })
+
+  const payload = await parseResponse(res)
+
+  if (!res.ok) {
+    const message =
+      payload && typeof payload === 'object' && 'error' in payload
+        ? payload.error
+        : 'Request failed'
+    throw new ApiError(String(message), res.status)
+  }
+
+  return payload
+}

--- a/front-end/src/api/fetchProductById.js
+++ b/front-end/src/api/fetchProductById.js
@@ -1,21 +1,12 @@
-// import { normalizeProduct } from '../listings/normalizeProduct'
-
-// export async function fetchProductById(id) {
-//   const num = Number(id)
-//   if (!Number.isFinite(num)) return null
-//   const r = await fetch(`https://dummyjson.com/products/${num}`)
-//   if (!r.ok) return null
-//   const p = await r.json()
-//   return normalizeProduct(p)
-// }
-
+import { getListingById } from './listings'
 
 export async function fetchProductById(id) {
   const num = Number(id)
   if (!Number.isFinite(num)) return null
 
-  const res = await fetch(`http://localhost:3000/api/listings/${num}`)
-  if (!res.ok) return null
-
-  return await res.json()
+  try {
+    return await getListingById(num)
+  } catch {
+    return null
+  }
 }

--- a/front-end/src/api/listings.js
+++ b/front-end/src/api/listings.js
@@ -1,0 +1,17 @@
+import { apiRequest } from './client'
+
+export function getListings() {
+  return apiRequest('/listings')
+}
+
+export function getListingById(id) {
+  return apiRequest(`/listings/${id}`)
+}
+
+export function createListing(payload) {
+  return apiRequest('/listings', {
+    method: 'POST',
+    body: payload,
+  })
+}
+

--- a/front-end/src/api/tenants.js
+++ b/front-end/src/api/tenants.js
@@ -1,0 +1,17 @@
+import { apiRequest } from './client'
+
+export function getTenants() {
+  return apiRequest('/tenants')
+}
+
+export function getTenantById(id) {
+  return apiRequest(`/tenants/${id}`)
+}
+
+export function createTenant(payload) {
+  return apiRequest('/tenants', {
+    method: 'POST',
+    body: payload,
+  })
+}
+

--- a/front-end/src/context/AuthProvider.jsx
+++ b/front-end/src/context/AuthProvider.jsx
@@ -1,0 +1,56 @@
+import { useEffect, useMemo, useState } from 'react'
+import { loginUser, registerUser } from '../api/auth'
+import { AuthContext } from './authContext'
+
+const STORAGE_KEY = 'subvet.authUser'
+
+function readStoredUser() {
+  if (typeof window === 'undefined') return null
+  try {
+    const value = window.localStorage.getItem(STORAGE_KEY)
+    return value ? JSON.parse(value) : null
+  } catch {
+    return null
+  }
+}
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(() => readStoredUser())
+
+  useEffect(() => {
+    if (user) {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(user))
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY)
+    }
+  }, [user])
+
+  async function login(credentials) {
+    const data = await loginUser(credentials)
+    setUser(data.user)
+    return data.user
+  }
+
+  async function register(details) {
+    const data = await registerUser(details)
+    setUser(data.user)
+    return data.user
+  }
+
+  function logout() {
+    setUser(null)
+  }
+
+  const value = useMemo(
+    () => ({
+      user,
+      isAuthenticated: Boolean(user),
+      login,
+      register,
+      logout,
+    }),
+    [user],
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}

--- a/front-end/src/context/ListingsProvider.jsx
+++ b/front-end/src/context/ListingsProvider.jsx
@@ -1,7 +1,6 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
+import { createListing as createListingRequest, getListings } from '../api/listings'
 import { ListingsContext } from './listingsContext'
-
-const LISTINGS_URL = 'http://localhost:3000/api/listings'
 
 export function ListingsProvider({ children }) {
   const [raw, setRaw] = useState([])
@@ -11,11 +10,7 @@ export function ListingsProvider({ children }) {
   useEffect(() => {
     let cancelled = false
 
-    fetch(LISTINGS_URL)
-      .then((r) => {
-        if (!r.ok) throw new Error('Could not load listings')
-        return r.json()
-      })
+    getListings()
       .then((data) => {
         if (!cancelled) setRaw(Array.isArray(data) ? data : [])
       })
@@ -32,29 +27,12 @@ export function ListingsProvider({ children }) {
   }, [])
 
   async function createListing(payload) {
-    const res = await fetch(LISTINGS_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(payload),
-    })
-
-    if (!res.ok) {
-      throw new Error('Could not create listing')
-    }
-
-    const created = await res.json()
+    const created = await createListingRequest(payload)
     setRaw((prev) => [...prev, created])
     return created
   }
 
-  const listings = useMemo(() => raw, [raw])
-
-  const value = useMemo(
-    () => ({ listings, loading, error, createListing }),
-    [listings, loading, error],
-  )
+  const value = { listings: raw, loading, error, createListing }
 
   return <ListingsContext.Provider value={value}>{children}</ListingsContext.Provider>
 }

--- a/front-end/src/context/TenantsProvider.jsx
+++ b/front-end/src/context/TenantsProvider.jsx
@@ -1,9 +1,6 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
+import { createTenant as createTenantRequest, getTenants } from '../api/tenants'
 import { TenantsContext } from './tenantsContext'
-import { normalizeDummyUser } from '../tenants/normalizeDummyUser'
-
-const USERS_URL =
-  'https://dummyjson.com/users?limit=8&select=id,firstName,lastName,age,company,address,university'
 
 export function TenantsProvider({ children }) {
   const [raw, setRaw] = useState([])
@@ -12,13 +9,9 @@ export function TenantsProvider({ children }) {
 
   useEffect(() => {
     let cancelled = false
-    fetch(USERS_URL)
-      .then((r) => {
-        if (!r.ok) throw new Error('Could not load tenants')
-        return r.json()
-      })
+    getTenants()
       .then((data) => {
-        if (!cancelled) setRaw(Array.isArray(data.users) ? data.users : [])
+        if (!cancelled) setRaw(Array.isArray(data) ? data : [])
       })
       .catch(() => {
         if (!cancelled) setError('Unable to reach the tenant directory. Check your connection.')
@@ -31,12 +24,13 @@ export function TenantsProvider({ children }) {
     }
   }, [])
 
-  const tenants = useMemo(() => raw.map(normalizeDummyUser).filter(Boolean), [raw])
+  async function createTenant(payload) {
+    const created = await createTenantRequest(payload)
+    setRaw((prev) => [...prev, created])
+    return created
+  }
 
-  const value = useMemo(
-    () => ({ tenants, loading, error }),
-    [tenants, loading, error],
-  )
+  const value = { tenants: raw, loading, error, createTenant }
 
   return <TenantsContext.Provider value={value}>{children}</TenantsContext.Provider>
 }

--- a/front-end/src/context/authContext.js
+++ b/front-end/src/context/authContext.js
@@ -1,0 +1,4 @@
+import { createContext } from 'react'
+
+export const AuthContext = createContext(null)
+

--- a/front-end/src/hooks/useAuth.js
+++ b/front-end/src/hooks/useAuth.js
@@ -1,0 +1,9 @@
+import { useContext } from 'react'
+import { AuthContext } from '../context/authContext'
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider')
+  return ctx
+}
+


### PR DESCRIPTION
## Summary
- repair and extend the local Express backend so listings, tenants, auth, applications, and contact requests all have working in-memory API routes
- add a shared frontend API/auth layer and route tenant, auth, add-listing, apply, and contact flows through it
- remove remaining direct external tenant fetching so app data consistently goes through the local API

## Verification
- `cd front-end && npm run lint`
- `cd front-end && npm run build`
- `cd back-end && node -c server.js && node -c app.js`
- smoke tested backend routes locally for health, listing fetch, auth registration, and contact requests