### PR TITLE
Add persisted Sprint 2 profile flow

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -3,27 +3,55 @@ const express = require('express')
 const cors = require('cors')
 const seedListings = require('./listingsData')
 const seedTenants = require('./tenantsData')
-const initialListings = require('./listingsData')
-const tenants = require('./tenantsData')
 
 const app = express()
-
-/** In-memory listings (GET/POST can mutate; seed from mock data module) */
-let listings = [...initialListings]
 
 app.use(cors())
 app.use(express.json())
 
-let listings = seedListings.map((listing) => ({ ...listing }))
-let tenants = seedTenants.map((tenant) => ({ ...tenant }))
+function publicUser(user) {
+  return {
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    bio: user.bio,
+    avatarSeed: user.avatarSeed,
+  }
+}
+
+function defaultBio(name) {
+  return `${name} is looking for a clean and safe place near campus with good transit access.`
+}
+
+function buildUser({ id, name, email, password, bio, avatarSeed }) {
+  return {
+    id,
+    name,
+    email,
+    password,
+    bio: bio || defaultBio(name),
+    avatarSeed: avatarSeed || `subvet-user-${id}`,
+  }
+}
+
 let users = [
-  {
+  buildUser({
     id: 'demo',
     name: 'Kaiyuan Wu',
     email: 'demo@subvet.app',
     password: 'password123',
-  },
+    bio: 'Hi, I am looking for a clean and safe place near campus. I prefer a quiet environment and easy access to public transportation.',
+    avatarSeed: 'subvet-profile-demo',
+  }),
 ]
+
+let listings = seedListings.map((listing, index) => ({
+  ...listing,
+  ownerId: index < 2 ? 'demo' : null,
+  owner: index < 2 ? 'Kaiyuan Wu' : 'Other User',
+}))
+
+let tenants = seedTenants.map((tenant) => ({ ...tenant }))
 let applications = []
 let contactRequests = []
 
@@ -45,6 +73,27 @@ function nextNumericId(items) {
   return items.length > 0 ? Math.max(...items.map((item) => Number(item.id) || 0)) + 1 : 1
 }
 
+function nextUserId() {
+  return `user-${Date.now()}`
+}
+
+function normalizeListingOwner({ ownerId, owner }) {
+  if (!ownerId) {
+    return {
+      ownerId: null,
+      owner: owner ? String(owner).trim() : 'Kaiyuan Wu',
+    }
+  }
+
+  const user = findUserById(ownerId)
+  if (!user) return null
+
+  return {
+    ownerId: user.id,
+    owner: owner ? String(owner).trim() : user.name,
+  }
+}
+
 app.get('/health', (req, res) => res.json({ ok: true }))
 app.get('/api/health', (req, res) => res.json({ ok: true }))
 
@@ -55,13 +104,11 @@ app.get('/api/listings', (req, res) => {
 app.get('/api/listings/:id', (req, res) => {
   const id = Number(req.params.id)
   const listing = listings.find((item) => item.id === id)
+
   if (!listing) {
     return res.status(404).json({ error: 'Listing not found' })
-app.post('/api/listings', (req, res) => {
-  const { name, location, price, rating, details, description, owner } = req.body
-  if (!name || !location || !price) {
-    return res.status(400).json({ error: 'name, location, and price are required' })
   }
+
   return res.json(listing)
 })
 
@@ -74,6 +121,7 @@ app.post('/api/listings', (req, res) => {
     details,
     description,
     owner,
+    ownerId,
     bhk,
     area,
     rentUsd,
@@ -82,20 +130,20 @@ app.post('/api/listings', (req, res) => {
 
   if (!name || !location || !price) {
     return badRequest(res, 'name, location, and price are required')
-    rating: typeof rating === 'number' ? String(rating) : rating ?? '4.0',
-    details: details || 'Details',
-    description: description || 'No description provided yet.',
-    owner: owner || 'Unknown',
-    bhk: '1',
-    area: location,
-    rentUsd: 1000,
-    mapQuery: `${location}, New York, NY`,
   }
 
-  const nextId = nextNumericId(listings)
+  const normalizedOwner = normalizeListingOwner({
+    ownerId: ownerId ? String(ownerId) : null,
+    owner,
+  })
+
+  if (ownerId && !normalizedOwner) {
+    return res.status(404).json({ error: 'User not found' })
+  }
+
   const normalizedRent = Number(rentUsd)
   const listing = {
-    id: nextId,
+    id: nextNumericId(listings),
     name: String(name).trim(),
     location: String(location).trim(),
     price: String(price).trim(),
@@ -105,7 +153,8 @@ app.post('/api/listings', (req, res) => {
         : '4.5',
     details: details ? String(details).trim() : 'Private room · shared unit',
     description: description ? String(description).trim() : 'No description provided yet.',
-    owner: owner ? String(owner).trim() : 'Kaiyuan Wu',
+    owner: normalizedOwner?.owner ?? 'Kaiyuan Wu',
+    ownerId: normalizedOwner?.ownerId ?? null,
     bhk: bhk ? String(bhk) : 'room',
     area: area ? String(area).trim() : String(location).trim(),
     rentUsd: Number.isFinite(normalizedRent) ? normalizedRent : null,
@@ -116,26 +165,17 @@ app.post('/api/listings', (req, res) => {
   return res.status(201).json(listing)
 })
 
-app.get('/api/listings/:id', (req, res) => {
-  const id = Number(req.params.id)
-  const listing = listings.find((l) => l.id === id)
-
-  if (!listing) {
-    return res.status(404).json({ error: 'Listing not found' })
-  }
-
-  res.json(listing)
-})
-
 app.get('/api/tenants', (req, res) => {
   res.json(tenants)
 })
 
 app.get('/api/tenants/:id', (req, res) => {
   const tenant = tenants.find((item) => item.id === String(req.params.id))
+
   if (!tenant) {
     return res.status(404).json({ error: 'Tenant not found' })
   }
+
   return res.json(tenant)
 })
 
@@ -156,9 +196,8 @@ app.post('/api/tenants', (req, res) => {
     return badRequest(res, 'displayName, age, neighborhoods, and subleaseWindow are required')
   }
 
-  const nextId = String(nextNumericId(tenants))
   const tenant = {
-    id: nextId,
+    id: String(nextNumericId(tenants)),
     displayName: String(displayName).trim(),
     age: Number(age),
     neighborhoods: String(neighborhoods).trim(),
@@ -172,7 +211,7 @@ app.post('/api/tenants', (req, res) => {
       : 'Furnished or lightly furnished, respectful roommates if shared.',
     questions: questions ? String(questions).trim() : 'No questions yet.',
     company: company ? String(company).trim() : 'Summer internship',
-    avatarSeed: `subvet-tenant-${nextId}`,
+    avatarSeed: `subvet-tenant-${nextNumericId(tenants)}`,
   }
 
   tenants.push(tenant)
@@ -194,21 +233,18 @@ app.post('/api/auth/login', (req, res) => {
 
   const user =
     existing ??
-    {
-      id: `user-${Date.now()}`,
-      name: email.split('@')[0],
+    buildUser({
+      id: nextUserId(),
+      name: email.split('@')[0] || 'User',
       email,
       password,
-    }
+    })
 
   if (!existing) {
     users.push(user)
   }
 
-  return res.json({
-    ok: true,
-    user: { id: user.id, name: user.name, email: user.email },
-  })
+  return res.json({ ok: true, user: publicUser(user) })
 })
 
 app.post('/api/auth/register', (req, res) => {
@@ -224,18 +260,73 @@ app.post('/api/auth/register', (req, res) => {
     return res.status(409).json({ error: 'An account with this email already exists' })
   }
 
-  const user = {
-    id: `user-${Date.now()}`,
+  const user = buildUser({
+    id: nextUserId(),
     name,
     email,
     password,
-  }
+  })
 
   users.push(user)
-  return res.status(201).json({
-    ok: true,
-    user: { id: user.id, name: user.name, email: user.email },
+  return res.status(201).json({ ok: true, user: publicUser(user) })
+})
+
+app.get('/api/users/:id', (req, res) => {
+  const user = findUserById(req.params.id)
+
+  if (!user) {
+    return res.status(404).json({ error: 'User not found' })
+  }
+
+  return res.json(publicUser(user))
+})
+
+app.patch('/api/users/:id', (req, res) => {
+  const user = findUserById(req.params.id)
+
+  if (!user) {
+    return res.status(404).json({ error: 'User not found' })
+  }
+
+  const incoming = req.body ?? {}
+  const nextName =
+    incoming.name === undefined ? user.name : String(incoming.name).trim()
+  const nextBio = incoming.bio === undefined ? user.bio : String(incoming.bio).trim()
+  const nextAvatarSeed =
+    incoming.avatarSeed === undefined
+      ? user.avatarSeed
+      : String(incoming.avatarSeed).trim()
+
+  if (!nextName) {
+    return badRequest(res, 'name cannot be empty')
+  }
+
+  if (!nextBio) {
+    return badRequest(res, 'bio cannot be empty')
+  }
+
+  if (!nextAvatarSeed) {
+    return badRequest(res, 'avatarSeed cannot be empty')
+  }
+
+  const previousName = user.name
+  user.name = nextName
+  user.bio = nextBio
+  user.avatarSeed = nextAvatarSeed
+
+  listings = listings.map((listing) => {
+    if (listing.ownerId === user.id) {
+      return { ...listing, owner: user.name }
+    }
+
+    if (!listing.ownerId && listing.owner === previousName) {
+      return { ...listing, owner: user.name }
+    }
+
+    return listing
   })
+
+  return res.json(publicUser(user))
 })
 
 app.post('/api/applications', (req, res) => {

--- a/front-end/src/AddListingPage.jsx
+++ b/front-end/src/AddListingPage.jsx
@@ -73,6 +73,7 @@ function AddListingPage() {
           details: formatWindow(form.sublessorFrom, form.sublessorTo),
           description: form.sublessorDetails || 'New sublease listing',
           owner: actorName,
+          ownerId: user?.id ?? null,
           bhk: 'room',
           area: form.sublessorAddress || 'New York',
           rentUsd: Number(form.sublessorPrice),

--- a/front-end/src/ProfilePage.css
+++ b/front-end/src/ProfilePage.css
@@ -153,6 +153,19 @@
   border-radius: 999px;
 }
 
+.profile-hint,
+.profile-state {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: var(--lp-muted);
+  text-align: center;
+}
+
+.profile-state--error {
+  color: #b42318;
+}
+
 .profile-section {
   display: flex;
   flex-direction: column;
@@ -192,9 +205,53 @@
   background: rgba(0, 0, 0, 0.04);
 }
 
+.profile-action-row {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.profile-save-btn {
+  border: 1px solid var(--lp-ink);
+  background: var(--lp-ink);
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--lp-surface);
+  cursor: pointer;
+  padding: 0.35rem 0.75rem;
+  border-radius: 10px;
+}
+
+.profile-save-btn:disabled,
+.profile-edit-btn:disabled,
+.profile-session-btn:disabled {
+  cursor: wait;
+  opacity: 0.72;
+}
+
+.profile-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.profile-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.profile-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--lp-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.profile-input,
 .profile-textarea {
   width: 100%;
-  min-height: 5.5rem;
   padding: 0.75rem 0.875rem;
   border: 1px solid var(--lp-line-soft);
   border-radius: 14px;
@@ -203,13 +260,29 @@
   line-height: 1.45;
   color: var(--lp-ink);
   background: #fafafa;
+}
+
+.profile-textarea {
+  min-height: 5.5rem;
   resize: vertical;
 }
 
+.profile-input:focus,
 .profile-textarea:focus {
   outline: 2px solid var(--lp-ink);
   outline-offset: 1px;
   background: #fff;
+}
+
+.profile-status {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  color: #156f3b;
+}
+
+.profile-status--error {
+  color: #b42318;
 }
 
 .profile-info-box {

--- a/front-end/src/ProfilePage.jsx
+++ b/front-end/src/ProfilePage.jsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { getUserById, updateUserById } from './api/users'
 import ListingCard from './ListingCard'
 import MainNav from './MainNav'
 import { useAuth } from './hooks/useAuth'
@@ -7,18 +8,102 @@ import { useListings } from './hooks/useListings'
 import './ProfilePage.css'
 
 function ProfilePage() {
-  const { user, logout } = useAuth()
+  const navigate = useNavigate()
+  const { user, logout, syncUserProfile } = useAuth()
   const { listings, loading } = useListings()
-  const profileName = user?.name || 'Kaiyuan Wu'
-  const profileEmail = user?.email || 'demo@subvet.app'
-  const myListings = useMemo(
-    () => listings.filter((listing) => listing.owner === profileName),
-    [listings, profileName],
-  )
+  const activeUserId = user?.id ?? 'demo'
+  const [profile, setProfile] = useState(null)
+  const [profileError, setProfileError] = useState('')
+  const [profileLoading, setProfileLoading] = useState(true)
   const [isEditing, setIsEditing] = useState(false)
-  const [info, setInfo] = useState(
-    'Hi, I am looking for a clean and safe place near campus. I prefer a quiet environment and easy access to public transportation.',
+  const [draftName, setDraftName] = useState('')
+  const [draftBio, setDraftBio] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [saveStatus, setSaveStatus] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    setProfileLoading(true)
+    setProfileError('')
+
+    getUserById(activeUserId)
+      .then((nextProfile) => {
+        if (cancelled) return
+        setProfile(nextProfile)
+        setDraftName(nextProfile.name)
+        setDraftBio(nextProfile.bio)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setProfileError(err.message || 'Could not load your profile right now.')
+      })
+      .finally(() => {
+        if (!cancelled) setProfileLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [activeUserId])
+
+  const profileName = profile?.name ?? user?.name ?? 'Kaiyuan Wu'
+  const profileEmail = profile?.email ?? user?.email ?? 'demo@subvet.app'
+  const profileAvatarSeed = profile?.avatarSeed ?? profileName
+  const profileId = profile?.id ?? user?.id ?? null
+
+  const myListings = useMemo(
+    () =>
+      listings.filter(
+        (listing) =>
+          (profileId && listing.ownerId === profileId) ||
+          (!listing.ownerId && listing.owner === profileName),
+      ),
+    [listings, profileId, profileName],
   )
+
+  function handleStartEdit() {
+    if (!user) {
+      navigate('/login')
+      return
+    }
+
+    setSaveStatus('')
+    setIsEditing(true)
+  }
+
+  function handleCancelEdit() {
+    setDraftName(profile?.name ?? '')
+    setDraftBio(profile?.bio ?? '')
+    setSaveStatus('')
+    setIsEditing(false)
+  }
+
+  async function handleSaveProfile() {
+    if (!user || !profile) {
+      navigate('/login')
+      return
+    }
+
+    setSaving(true)
+    setSaveStatus('')
+
+    try {
+      const updated = await updateUserById(profile.id, {
+        name: draftName,
+        bio: draftBio,
+      })
+      setProfile(updated)
+      setDraftName(updated.name)
+      setDraftBio(updated.bio)
+      syncUserProfile(updated)
+      setSaveStatus('Profile updated.')
+      setIsEditing(false)
+    } catch (err) {
+      setSaveStatus(err.message || 'Could not update your profile right now.')
+    } finally {
+      setSaving(false)
+    }
+  }
 
   return (
     <div className="profile-page">
@@ -42,19 +127,29 @@ function ProfilePage() {
           <div className="profile-hero">
             <div className="profile-avatar">
               <img
-                src={`https://picsum.photos/seed/${encodeURIComponent(profileName)}/120/120`}
+                src={`https://picsum.photos/seed/${encodeURIComponent(profileAvatarSeed)}/120/120`}
                 alt=""
                 width={120}
                 height={120}
               />
             </div>
-            <h2 className="profile-username">{profileName}</h2>
-            <p className="profile-email">{profileEmail}</p>
-            {user ? (
-              <button type="button" className="profile-session-btn" onClick={logout}>
-                Sign out
-              </button>
-            ) : null}
+            {profileLoading ? (
+              <p className="profile-state">Loading profile…</p>
+            ) : profileError ? (
+              <p className="profile-state profile-state--error">{profileError}</p>
+            ) : (
+              <>
+                <h2 className="profile-username">{profileName}</h2>
+                <p className="profile-email">{profileEmail}</p>
+                {user ? (
+                  <button type="button" className="profile-session-btn" onClick={logout}>
+                    Sign out
+                  </button>
+                ) : (
+                  <p className="profile-hint">Sign in to edit your profile and save listings.</p>
+                )}
+              </>
+            )}
           </div>
 
           <section className="profile-section" aria-labelledby="profile-about-heading">
@@ -62,24 +157,69 @@ function ProfilePage() {
               <h2 id="profile-about-heading" className="profile-section-title">
                 About
               </h2>
-              <button
-                type="button"
-                className="profile-edit-btn"
-                onClick={() => setIsEditing(!isEditing)}
-              >
-                {isEditing ? 'Done' : 'Edit'}
-              </button>
+              {isEditing ? (
+                <div className="profile-action-row">
+                  <button
+                    type="button"
+                    className="profile-edit-btn"
+                    onClick={handleCancelEdit}
+                    disabled={saving}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="profile-save-btn"
+                    onClick={handleSaveProfile}
+                    disabled={saving}
+                  >
+                    {saving ? 'Saving...' : 'Save'}
+                  </button>
+                </div>
+              ) : (
+                <button type="button" className="profile-edit-btn" onClick={handleStartEdit}>
+                  Edit
+                </button>
+              )}
             </div>
 
             {isEditing ? (
-              <textarea
-                className="profile-textarea"
-                value={info}
-                onChange={(e) => setInfo(e.target.value)}
-              />
+              <div className="profile-form">
+                <label className="profile-field">
+                  <span className="profile-label">Display name</span>
+                  <input
+                    className="profile-input"
+                    type="text"
+                    value={draftName}
+                    onChange={(e) => setDraftName(e.target.value)}
+                    disabled={saving}
+                  />
+                </label>
+                <label className="profile-field">
+                  <span className="profile-label">About</span>
+                  <textarea
+                    className="profile-textarea"
+                    value={draftBio}
+                    onChange={(e) => setDraftBio(e.target.value)}
+                    disabled={saving}
+                  />
+                </label>
+              </div>
             ) : (
-              <div className="profile-info-box">{info}</div>
+              <div className="profile-info-box">{profile?.bio ?? 'No profile information yet.'}</div>
             )}
+
+            {saveStatus ? (
+              <p
+                className={
+                  saveStatus === 'Profile updated.'
+                    ? 'profile-status'
+                    : 'profile-status profile-status--error'
+                }
+              >
+                {saveStatus}
+              </p>
+            ) : null}
           </section>
 
           <section className="profile-section" aria-labelledby="profile-listings-heading">

--- a/front-end/src/api/users.js
+++ b/front-end/src/api/users.js
@@ -1,0 +1,13 @@
+import { apiRequest } from './client'
+
+export function getUserById(id) {
+  return apiRequest(`/users/${id}`)
+}
+
+export function updateUserById(id, payload) {
+  return apiRequest(`/users/${id}`, {
+    method: 'PATCH',
+    body: payload,
+  })
+}
+

--- a/front-end/src/context/AuthProvider.jsx
+++ b/front-end/src/context/AuthProvider.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { loginUser, registerUser } from '../api/auth'
 import { AuthContext } from './authContext'
 
@@ -41,16 +41,21 @@ export function AuthProvider({ children }) {
     setUser(null)
   }
 
-  const value = useMemo(
-    () => ({
-      user,
-      isAuthenticated: Boolean(user),
-      login,
-      register,
-      logout,
-    }),
-    [user],
-  )
+  function syncUserProfile(nextUser) {
+    setUser((current) => {
+      if (!current || current.id !== nextUser.id) return current
+      return nextUser
+    })
+  }
+
+  const value = {
+    user,
+    isAuthenticated: Boolean(user),
+    login,
+    register,
+    logout,
+    syncUserProfile,
+  }
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }


### PR DESCRIPTION
## Summary
- repair the broken backend app state and restore a consistent runnable in-memory API baseline
- add backend user profile read/update endpoints and sync listing ownership through stable `ownerId`
- persist profile edits from the frontend and keep auth/profile state aligned after save

## Verification
- `cd back-end && node -c app.js && node -c server.js`
- `cd front-end && npm run lint`
- `cd front-end && npm run build`
- live API smoke tests on `PORT=4011` for health, users, profile update, listings, auth register, tenants, applications, and contact requests