### PR TITLE
Add applied listings section with application status on profile page

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -478,6 +478,27 @@ app.post(
   },
 )
 
+app.get(
+  '/api/users/:id/applications',
+  requireAuth,
+  userIdParamValidation,
+  requireAuthForUserParam,
+  async (req, res) => {
+    try {
+      const userId = String(req.params.id)
+
+      const applications = await Application.find({ userId }).sort({ createdAt: -1 }).lean()
+      const listingIds = applications.map((item) => item.listingId)
+
+      const appliedListings = await Listing.find({ id: { $in: listingIds } }).sort({ id: 1 }).lean()
+
+      return res.json(appliedListings)
+    } catch {
+      return res.status(500).json({ error: 'Failed to load applied listings' })
+    }
+  },
+)
+
 app.delete(
   '/api/users/:id/saved-listings/:listingId',
   requireAuth,
@@ -729,6 +750,33 @@ app.patch(
       return res.json(publicUser(user))
     } catch {
       return res.status(500).json({ error: 'Failed to update profile' })
+    }
+  },
+)
+
+app.get(
+  '/api/users/:id/applications',
+  requireAuth,
+  userIdParamValidation,
+  requireAuthForUserParam,
+  async (req, res) => {
+    try {
+      const userId = String(req.params.id)
+
+      const applications = await Application.find({ userId }).sort({ createdAt: -1 }).lean()
+      const listingIds = applications.map((item) => item.listingId)
+
+      const listings = await Listing.find({ id: { $in: listingIds } }).sort({ id: 1 }).lean()
+
+      const appliedListings = listings.map((listing) => ({
+        ...listing,
+        applicationStatus: 'Submitted',
+        applicationNote: 'Waiting for owner response',
+      }))
+
+      return res.json(appliedListings)
+    } catch {
+      return res.status(500).json({ error: 'Failed to load applied listings' })
     }
   },
 )

--- a/front-end/src/ProfilePage.css
+++ b/front-end/src/ProfilePage.css
@@ -315,3 +315,39 @@
   line-height: 1.45;
   color: var(--lp-muted);
 }
+
+
+.profile-applied-card {
+  border: 1px solid var(--lp-line-soft);
+  border-radius: 18px;
+  padding: 0.625rem;
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.profile-application-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0 0.25rem;
+}
+
+.profile-status-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.25rem 0.55rem;
+  background: #0a0a0a;
+  color: #ffffff;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.profile-status-text {
+  font-size: 0.75rem;
+  color: var(--lp-muted);
+  text-align: right;
+}

--- a/front-end/src/ProfilePage.jsx
+++ b/front-end/src/ProfilePage.jsx
@@ -6,6 +6,7 @@ import MainNav from './MainNav'
 import { useAuth } from './hooks/useAuth'
 import { useListings } from './hooks/useListings'
 import './ProfilePage.css'
+import { getUserApplications } from './api/applications'
 
 function ProfilePage() {
   const navigate = useNavigate()
@@ -20,6 +21,9 @@ function ProfilePage() {
   const [draftBio, setDraftBio] = useState('')
   const [saving, setSaving] = useState(false)
   const [saveStatus, setSaveStatus] = useState('')
+  const [appliedListings, setAppliedListings] = useState([])
+  const [appliedLoading, setAppliedLoading] = useState(false)
+  const [appliedError, setAppliedError] = useState('')
 
   useEffect(() => {
     let cancelled = false
@@ -45,6 +49,34 @@ function ProfilePage() {
       cancelled = true
     }
   }, [activeUserId])
+
+  useEffect(() => {
+    if (!user || !activeUserId) {
+      setAppliedListings([])
+      return
+    }
+
+    let cancelled = false
+    setAppliedLoading(true)
+    setAppliedError('')
+
+    getUserApplications(activeUserId)
+      .then((listings) => {
+        if (cancelled) return
+        setAppliedListings(listings ?? [])
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setAppliedError(err.message || 'Could not load applied listings right now.')
+      })
+      .finally(() => {
+        if (!cancelled) setAppliedLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [user, activeUserId])
 
   const profileName = profile?.name ?? user?.name ?? 'Kaiyuan Wu'
   const profileEmail = profile?.email ?? user?.email ?? 'demo@subvet.app'
@@ -224,13 +256,13 @@ function ProfilePage() {
 
           <section className="profile-section" aria-labelledby="profile-listings-heading">
             <h2 id="profile-listings-heading" className="profile-listings-title">
-              My listings
+              Created listings
             </h2>
 
             {loading ? (
               <p className="profile-listings-hint">Loading listings…</p>
             ) : myListings.length === 0 ? (
-              <p className="profile-listings-hint">No listings yet.</p>
+              <p className="profile-listings-hint">No created listings yet.</p>
             ) : (
               <div className="profile-listings-stack">
                 {myListings.map((listing) => (
@@ -246,6 +278,42 @@ function ProfilePage() {
                     details={listing.details}
                     showFavorite={false}
                   />
+                ))}
+              </div>
+            )}
+          </section>
+          <section className="profile-section" aria-labelledby="profile-applied-listings-heading">
+            <h2 id="profile-applied-listings-heading" className="profile-listings-title">
+              Applied listings
+            </h2>
+
+            {appliedLoading ? (
+              <p className="profile-listings-hint">Loading applied listings…</p>
+            ) : appliedError ? (
+              <p className="profile-listings-hint">{appliedError}</p>
+            ) : appliedListings.length === 0 ? (
+              <p className="profile-listings-hint">No applied listings yet.</p>
+            ) : (
+              <div className="profile-listings-stack">
+                {appliedListings.map((listing) => (
+                  <div className="profile-applied-card" key={listing.id}>
+                    <div className="profile-application-status">
+                      <span className="profile-status-badge">Submitted</span>
+                      <span className="profile-status-text">Waiting for owner response</span>
+                    </div>
+
+                    <ListingCard
+                      variant="feed"
+                      to={`/listing/${listing.id}`}
+                      name={listing.name}
+                      location={listing.location}
+                      price={listing.price}
+                      imageSeed={`subvet-${listing.id}`}
+                      rating={listing.rating}
+                      details={listing.details}
+                      showFavorite={false}
+                    />
+                  </div>
                 ))}
               </div>
             )}

--- a/front-end/src/api/applications.js
+++ b/front-end/src/api/applications.js
@@ -1,0 +1,5 @@
+import { apiRequest } from './client'
+
+export function getUserApplications(userId) {
+  return apiRequest(`/users/${userId}/applications`)
+}


### PR DESCRIPTION
This PR improves the profile page by separating created listings and applied listings.

Changes:
- Renamed "My listings" to "Created listings"
- Added a new "Applied listings" section
- Display applied listings using existing listing cards
- Added application status UI (Submitted / Waiting for owner response)

Backend:
- Uses existing application records stored in MongoDB
- Fetches applied listings through user-specific API

This makes the profile page more meaningful by showing the user's application history instead of duplicating the main listings feed.

Future improvements:
- Support application status updates (approved / rejected)
- Add cancel application functionality